### PR TITLE
Improve README with install and usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # botML
+
+A simple bot that downloads 1‑minute candlestick data for the top 30 symbols on Binance (excluding common stablecoins) and stores the information in a local SQLite database.
+
+## Requirements
+
+Install Python dependencies using the provided requirements file:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script from the project directory:
+
+```bash
+python bot.py
+```
+
+During execution the bot prints progress for each symbol and creates `binance_1m.db`.
+Each trading pair is saved in its own table prefixed with an underscore (for example, `_BTCUSDT`).
+
+To inspect the stored data you can query the database:
+
+```bash
+sqlite3 binance_1m.db "SELECT * FROM _BTCUSDT LIMIT 1;"
+```
+
+Example output will resemble:
+
+```
+2024-01-01 00:00:00|43000|43200|42900|43100|12.345|...
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pandas


### PR DESCRIPTION
## Summary
- expand README with project overview, install steps and example usage
- add `requirements.txt` listing Python dependencies

## Testing
- `pip install requests pandas`
- `python3 bot.py` *(fails: Service unavailable from Binance)*

------
https://chatgpt.com/codex/tasks/task_e_6860711e8b4883318d4b1b488d3a4fb3