### PR TITLE
Add .gitignore for Python artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.py[cod]
+*.sqlite3
+*.db
+.Python
+.env
+.venv
+*.egg-info/
+dist/
+build/
+.pytest_cache/


### PR DESCRIPTION
## Summary
- add .gitignore to ignore common Python build artifacts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ac9a14d8833193d05b2dc52506c7