### PR TITLE
Add backtesting and Binance trading modules

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -1,0 +1,90 @@
+"""Backtesting utilities for running strategies on historical data."""
+
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+import pandas as pd
+
+from risk import PositionSizer, RiskManager
+from utils import load_config, setup_logging
+
+CONFIG = load_config()
+setup_logging(CONFIG)
+
+
+@dataclass
+class Trade:
+    entry_index: int
+    entry_price: float
+    direction: str
+    size: float
+    stop: float
+    take_profit: float
+    exit_index: Optional[int] = None
+    exit_price: Optional[float] = None
+
+
+class Backtester:
+    """Simple backtester using close prices and shared risk logic."""
+
+    def __init__(self, data: pd.DataFrame, strategy: Callable[[pd.Series], Optional[str]],
+                 account_size: float = 1000.0,
+                 risk_manager: Optional[RiskManager] = None,
+                 sizer: Optional[PositionSizer] = None):
+        self.data = data.reset_index(drop=True)
+        self.strategy = strategy
+        self.account_size = account_size
+        self.risk_manager = risk_manager or RiskManager(account_size)
+        self.sizer = sizer or PositionSizer(account_size)
+        self.equity = account_size
+        self.trades: List[Trade] = []
+        self.open_trade: Optional[Trade] = None
+
+    def _close_trade(self, index: int, price: float):
+        if not self.open_trade:
+            return
+        trade = self.open_trade
+        trade.exit_index = index
+        trade.exit_price = price
+        if trade.direction == 'long':
+            pnl = (price - trade.entry_price) * trade.size
+        else:
+            pnl = (trade.entry_price - price) * trade.size
+        self.equity += pnl
+        self.open_trade = None
+
+    def run(self) -> float:
+        for i, row in self.data.iterrows():
+            price = float(row['close'])
+            high = float(row.get('high', price))
+            low = float(row.get('low', price))
+
+            if self.open_trade:
+                t = self.open_trade
+                if t.direction == 'long':
+                    if low <= t.stop:
+                        self._close_trade(i, t.stop)
+                        continue
+                    if high >= t.take_profit:
+                        self._close_trade(i, t.take_profit)
+                        continue
+                else:
+                    if high >= t.stop:
+                        self._close_trade(i, t.stop)
+                        continue
+                    if low <= t.take_profit:
+                        self._close_trade(i, t.take_profit)
+                        continue
+
+            signal = self.strategy(row)
+            if signal in ('long', 'short') and self.open_trade is None:
+                stop = self.risk_manager.stop_loss_price(price, signal)
+                take_profit = self.risk_manager.take_profit_price(price, signal)
+                size = self.sizer.size_from_stop(price, stop)
+                self.open_trade = Trade(i, price, signal, size, stop, take_profit)
+                self.trades.append(self.open_trade)
+
+        if self.open_trade:
+            # Close any remaining open trade at final price
+            self._close_trade(len(self.data) - 1, float(self.data.iloc[-1]['close']))
+        return self.equity

--- a/config.yaml
+++ b/config.yaml
@@ -11,3 +11,6 @@ interval: '1m'
 log_level: INFO
 # Path to the log file
 log_file: bot.log
+# API credentials for live trading
+api_key: ""
+api_secret: ""

--- a/live_trading.py
+++ b/live_trading.py
@@ -1,9 +1,49 @@
-"""Simple live trading skeleton using the risk module."""
+"""Live trading module using Binance REST API and shared risk logic."""
 
+import time
+import hmac
+import hashlib
 from dataclasses import dataclass
 from typing import Optional
+from urllib.parse import urlencode
+
+import requests
 
 from risk import PositionSizer, RiskManager
+from utils import load_config, setup_logging
+
+CONFIG = load_config()
+setup_logging(CONFIG)
+
+BINANCE_URL = CONFIG.get('api_url', 'https://api.binance.com')
+API_KEY = CONFIG.get('api_key')
+API_SECRET = CONFIG.get('api_secret')
+
+
+class BinanceClient:
+    """Minimal Binance REST API client for order execution."""
+
+    def __init__(self, api_key: str, api_secret: str, base_url: str = BINANCE_URL):
+        self.api_key = api_key
+        self.api_secret = api_secret.encode()
+        self.base_url = base_url
+        self.session = requests.Session()
+        if api_key:
+            self.session.headers.update({'X-MBX-APIKEY': api_key})
+
+    def _sign_params(self, params: dict) -> dict:
+        query = urlencode(params)
+        signature = hmac.new(self.api_secret, query.encode(), hashlib.sha256).hexdigest()
+        params['signature'] = signature
+        return params
+
+    def create_order(self, **params):
+        params.setdefault('timestamp', int(time.time() * 1000))
+        signed = self._sign_params(params)
+        response = self.session.post(self.base_url + '/api/v3/order', params=signed, timeout=10)
+        response.raise_for_status()
+        return response.json()
+
 
 @dataclass
 class Trade:
@@ -13,21 +53,28 @@ class Trade:
     stop: float
     take_profit: float
 
+
 class LiveTrader:
-    def __init__(self, account_size: float,
+    """Execute trades on Binance using risk management utilities."""
+
+    def __init__(self, symbol: str, account_size: float,
+                 client: Optional[BinanceClient] = None,
                  risk_manager: Optional[RiskManager] = None,
                  sizer: Optional[PositionSizer] = None):
+        self.symbol = symbol
         self.account_size = account_size
+        self.client = client or BinanceClient(API_KEY, API_SECRET)
         self.sizer = sizer or PositionSizer(account_size)
         self.risk_manager = risk_manager or RiskManager(account_size)
         self.open_trades = []
 
-    def open_trade(self, entry_price: float, direction: str = "long") -> Trade:
-        stop = self.risk_manager.stop_loss_price(entry_price, direction)
-        take_profit = self.risk_manager.take_profit_price(entry_price, direction)
-        size = self.sizer.size_from_stop(entry_price, stop)
-        trade = Trade(entry_price, direction, size, stop, take_profit)
-        # In a real implementation, send order to exchange here
+    def open_trade(self, price: float, direction: str = "long") -> Trade:
+        stop = self.risk_manager.stop_loss_price(price, direction)
+        take_profit = self.risk_manager.take_profit_price(price, direction)
+        size = self.sizer.size_from_stop(price, stop)
+        side = 'BUY' if direction == 'long' else 'SELL'
+        order = self.client.create_order(symbol=self.symbol, side=side, type='MARKET', quantity=size)
+        trade = Trade(price, direction, size, stop, take_profit)
         self.open_trades.append(trade)
         return trade
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,21 @@
+import logging
+from pathlib import Path
+import yaml
+
+
+def load_config():
+    """Load configuration from config.yaml located next to this file."""
+    with open(Path(__file__).resolve().parent / 'config.yaml', 'r') as fh:
+        return yaml.safe_load(fh)
+
+
+def setup_logging(config):
+    """Configure logging based on a configuration dictionary."""
+    level_name = config.get('log_level', 'INFO').upper()
+    log_file = config.get('log_file', 'bot.log')
+    logging.basicConfig(
+        level=getattr(logging, level_name, logging.INFO),
+        format='%(asctime)s %(levelname)s: %(message)s',
+        handlers=[logging.StreamHandler(),
+                  logging.FileHandler(log_file, encoding='utf-8')]
+    )


### PR DESCRIPTION
## Summary
- centralize config loading and logger setup in `utils.py`
- add example API credential fields in `config.yaml`
- implement a simple backtesting engine in `backtest.py`
- overhaul `live_trading.py` to send signed orders to Binance

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68613edb51288331aae3bb530221b627