### PR TITLE
Clarify training setup and handle missing table

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Each trading pair is saved in its own table prefixed with an underscore (for exa
 
 The training script `train_model.py` also reads the database path and target symbol from the same configuration file.
 
+To train a model on a specific pair, include that pair in the `symbols` list
+before running `bot.py` so the corresponding table exists.
+
 To inspect the stored data you can query the database:
 
 ```bash

--- a/train_model.py
+++ b/train_model.py
@@ -16,8 +16,15 @@ SYMBOL = (CONFIG.get('symbols') or ['BTCUSDT'])[0]
 # 1. Cargar datos históricos
 conn = sqlite3.connect(DB_PATH)
 table = f"_{SYMBOL}"
-df = pd.read_sql(f'SELECT * FROM {table}', conn)
-conn.close()
+try:
+    df = pd.read_sql(f'SELECT * FROM {table}', conn)
+except Exception as exc:
+    raise SystemExit(
+        f"Table {table} not found in {DB_PATH}. "
+        "Run bot.py with this symbol configured first."
+    ) from exc
+finally:
+    conn.close()
 
 # 2. Procesar features
 df['return_5'] = df['close'].pct_change(5)


### PR DESCRIPTION
## Summary
- add explicit check for missing table in `train_model.py`
- document that symbols must be specified before running `bot.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686148e8e4e883319790e16a1318f1f5