### PR TITLE
Improve error message when table missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ Each trading pair is saved in its own table prefixed with an underscore (for exa
 
 The training script `train_model.py` also reads the database path and target symbol from the same configuration file.
 
-To train a model on a specific pair, include that pair in the `symbols` list
-before running `bot.py` so the corresponding table exists.
+`train_model.py` uses the first entry in `symbols` as its target. If the list is
+empty it defaults to `BTCUSDT`, which isn't downloaded when running
+`bot.py` with the default symbol selection (stablecoin pairs are filtered out).
+Therefore, to train on `BTCUSDT` or any other pair, include it in the
+`symbols` list before running `bot.py` so the corresponding table exists.
 
 ```bash
 sqlite3 binance_1m.db "SELECT * FROM _BTCUSDT LIMIT 1;"

--- a/train_model.py
+++ b/train_model.py
@@ -19,9 +19,14 @@ table = f"_{SYMBOL}"
 try:
     df = pd.read_sql(f'SELECT * FROM {table}', conn)
 except Exception as exc:
+    tables = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    existing = ", ".join(t[0] for t in tables)
     raise SystemExit(
-        f"Table {table} not found in {DB_PATH}. "
-        "Run bot.py with this symbol configured first."
+        f"Table {table} not found in {DB_PATH}.\n"
+        "Run bot.py with this symbol configured first.\n"
+        f"Existing tables: {existing if existing else 'none'}"
     ) from exc
 finally:
     conn.close()


### PR DESCRIPTION
## Summary
- make `train_model.py` list existing tables when the target table is missing
- document how `train_model.py` defaults to BTCUSDT if `symbols` is empty

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861500ddd8c8331af4fc4a04f480e1d