### PR TITLE
Add quick run instructions

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -1,0 +1,2 @@
+Install dependencies with `pip install -r requirements.txt` and run the bot using `python bot.py`.
+


### PR DESCRIPTION
## Summary
- document a short command sequence for running the bot in `RUNNING.md`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686157ad37548331800ccfadd3361140