### PR TITLE
Fix train_model.py filename and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ features and labels and fits a `RandomForestClassifier`.
 python train_model.py
 ```
 
-The trained model is saved to `rf_btcusdt.pkl`.
+The trained model is saved to `rf_<symbol>.pkl` (en minúsculas).
 
 ## Hyperparameter optimization (`hyperoptimize.py`)
 

--- a/train_model.py
+++ b/train_model.py
@@ -54,5 +54,7 @@ preds = clf.predict(test[features])
 # ... calcula métricas de trading y precisión
 
 # 7. Guardar modelo
-with open('rf_btcusdt.pkl', 'wb') as f:
+model_path = f"rf_{SYMBOL.lower()}.pkl"
+with open(model_path, "wb") as f:
     pickle.dump(clf, f)
+print(f"Model saved to {model_path}")


### PR DESCRIPTION
## Summary
- save model to dynamic filename `rf_<symbol>.pkl`
- document lowercase filename in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686161ae46c883319e1aa1d28e046234