### PR TITLE
Dynamic model path for training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ features and labels and fits a `RandomForestClassifier`.
 python train_model.py
 ```
 
-The trained model is saved to `rf_btcusdt.pkl`.
+The trained model is saved to `rf_<symbol>.pkl`,
+where `<symbol>` is the current symbol in lowercase.
 
 ## Hyperparameter optimization (`hyperoptimize.py`)
 

--- a/train_model.py
+++ b/train_model.py
@@ -12,6 +12,7 @@ with open(Path(__file__).resolve().parent / 'config.yaml', 'r') as fh:
 
 DB_PATH = CONFIG.get('database_path', 'binance_1m.db')
 SYMBOL = (CONFIG.get('symbols') or ['BTCUSDT'])[0]
+model_path = f"rf_{SYMBOL.lower()}.pkl"
 
 # 1. Cargar datos históricos
 conn = sqlite3.connect(DB_PATH)
@@ -54,5 +55,6 @@ preds = clf.predict(test[features])
 # ... calcula métricas de trading y precisión
 
 # 7. Guardar modelo
-with open('rf_btcusdt.pkl', 'wb') as f:
+with open(model_path, 'wb') as f:
     pickle.dump(clf, f)
+print(f"Model saved to {model_path}")


### PR DESCRIPTION
## Summary
- save `train_model.py` output using the configured symbol
- confirm where the model was saved
- clarify model file naming in documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616076e35483318a47be32773af1cd