### PR TITLE
Replace deprecated freq usage

### DIFF
--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -7,7 +7,7 @@ from botml.features import add_features
 def sample_df(n=50):
     base = np.arange(n, dtype=float) + 100
     data = {
-        "open_time": pd.date_range("2024-01-01", periods=n, freq="T"),
+        "open_time": pd.date_range("2024-01-01", periods=n, freq="min"),
         "open": base,
         "high": base + 1,
         "low": base - 1,

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -5,24 +5,29 @@ from botml.features import add_features
 from botml.labeling import create_labels
 
 
+def _sigmoid(z):
+    z = np.clip(z, -50, 50)
+    return 1.0 / (1.0 + np.exp(-z))
+
+
 def logistic_train(X, y, lr=0.1, epochs=200):
     w = np.zeros(X.shape[1])
     for _ in range(epochs):
-        preds = 1.0 / (1.0 + np.exp(-X.dot(w)))
+        preds = _sigmoid(X.dot(w))
         gradient = X.T.dot(preds - y) / len(y)
         w -= lr * gradient
     return w
 
 
 def logistic_predict(X, w):
-    preds = 1.0 / (1.0 + np.exp(-X.dot(w)))
+    preds = _sigmoid(X.dot(w))
     return (preds >= 0.5).astype(int)
 
 
 def make_df(n=60):
     base = np.linspace(100, 101, n)
     data = {
-        "open_time": pd.date_range("2024-01-01", periods=n, freq="T"),
+        "open_time": pd.date_range("2024-01-01", periods=n, freq="min"),
         "open": base,
         "high": base + 1,
         "low": base - 1,


### PR DESCRIPTION
## Summary
- update dataframe creation in tests to use `freq="min"`
- stabilize logistic functions to avoid overflow warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861607b5dcc8331850f7649e720f08c