### PR TITLE
Add orchestrator workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,3 +143,17 @@ from live_trading import LiveTrader
 trader = LiveTrader('BTCUSDT', account_size=1000)
 trader.open_trade(price=30000, direction='long')
 ```
+
+## Orchestrator
+
+`orchestrator.py` combines the main pieces of the project. It downloads data,
+builds features and labels, trains a model and runs a backtest. Use the
+`--hyperopt` flag to perform a small hyperparameter search and `--live` to open a
+trade using `LiveTrader` if the final prediction is positive.
+
+```bash
+python orchestrator.py --hyperopt --live --report results.txt
+```
+
+The generated report summarizes the symbol, final equity from the backtest and
+the model path used.

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,120 @@
+import argparse
+import logging
+import pickle
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import GridSearchCV
+
+import bot
+from backtest import Backtester
+from live_trading import LiveTrader
+from botml.features import add_features
+from botml.labeling import create_labels
+from botml.utils import load_config, setup_logging
+
+
+def load_price_data(db_path: str, symbol: str) -> pd.DataFrame:
+    conn = sqlite3.connect(db_path)
+    table = f"_{symbol}"
+    df = pd.read_sql(f"SELECT * FROM {table}", conn)
+    conn.close()
+    return df
+
+
+def generate_features_and_labels(df: pd.DataFrame) -> pd.DataFrame:
+    df = add_features(df)
+    df = create_labels(df)
+    return df
+
+
+def train_random_forest(df: pd.DataFrame, model_path: Path) -> RandomForestClassifier:
+    features = [c for c in df.columns if c not in {'label', 'open_time'}]
+    X = df[features]
+    y = df['label']
+    split = int(len(df) * 0.7)
+    clf = RandomForestClassifier(n_estimators=100, random_state=42)
+    clf.fit(X.iloc[:split], y.iloc[:split])
+    pickle.dump(clf, open(model_path, 'wb'))
+    logging.info("Model saved to %s", model_path)
+    return clf
+
+
+def hyperopt_random_forest(df: pd.DataFrame, model_path: Path) -> RandomForestClassifier:
+    features = [c for c in df.columns if c not in {'label', 'open_time'}]
+    X = df[features]
+    y = df['label']
+    param_grid = {
+        'n_estimators': [50, 100],
+        'max_depth': [None, 5, 10],
+    }
+    base_model = RandomForestClassifier(random_state=42)
+    search = GridSearchCV(base_model, param_grid=param_grid, cv=3, n_jobs=-1)
+    search.fit(X, y)
+    best = search.best_estimator_
+    pickle.dump(best, open(model_path, 'wb'))
+    logging.info("Best model saved to %s", model_path)
+    return best
+
+
+def backtest_model(df: pd.DataFrame, model: RandomForestClassifier) -> float:
+    feat_cols = [c for c in df.columns if c not in {'label', 'open_time'}]
+
+    def strategy(row):
+        pred = model.predict(row[feat_cols].to_frame().T)[0]
+        return 'long' if pred == 1 else None
+
+    bt = Backtester(df, strategy)
+    equity = bt.run()
+    logging.info("Backtest finished with equity %.2f", equity)
+    return equity
+
+
+def run_live_trading(symbol: str, price: float, model: RandomForestClassifier, last_row: pd.Series):
+    feat_cols = [c for c in last_row.index if c not in {'label', 'open_time'}]
+    pred = model.predict(last_row[feat_cols].to_frame().T)[0]
+    if pred == 1:
+        trader = LiveTrader(symbol, account_size=1000)
+        trader.open_trade(price, direction='long')
+        logging.info("Live trade opened at price %.2f", price)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the botML workflow")
+    parser.add_argument('--hyperopt', action='store_true', help='Use hyperparameter optimization')
+    parser.add_argument('--live', action='store_true', help='Launch live trading after backtest')
+    parser.add_argument('--report', default='orchestrator_report.txt', help='Path to save the report file')
+    args = parser.parse_args()
+
+    config = load_config()
+    setup_logging(config)
+
+    logging.info("Starting data download")
+    bot.download_and_store_all()
+
+    db_path = config.get('database_path', 'binance_1m.db')
+    symbol = (config.get('symbols') or ['BTCUSDT'])[0]
+    df = load_price_data(db_path, symbol)
+    df = generate_features_and_labels(df)
+
+    model_path = Path('rf_best.pkl' if args.hyperopt else f'rf_{symbol.lower()}.pkl')
+    if args.hyperopt:
+        model = hyperopt_random_forest(df, model_path)
+    else:
+        model = train_random_forest(df, model_path)
+
+    equity = backtest_model(df, model)
+
+    if args.live:
+        run_live_trading(symbol, float(df.iloc[-1]['close']), model, df.iloc[-1])
+
+    report = f"Symbol: {symbol}\nFinal equity: {equity:.2f}\nModel: {model_path}\n"
+    with open(args.report, 'w') as fh:
+        fh.write(report)
+    logging.info("Report written to %s", args.report)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `orchestrator.py` with sequential workflow for downloading data, feature generation, model training, backtesting and optional live trading
- document orchestrator usage in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c15935c48331bf9ca51ecd29e95e