### PR TITLE
Add walk-forward optimization module

### DIFF
--- a/botml/__init__.py
+++ b/botml/__init__.py
@@ -4,6 +4,7 @@ from .features import add_features
 from .labeling import create_labels
 from .risk import PositionSizer, RiskManager
 from .utils import load_config, setup_logging
+from .walkforward import rolling_windows, walk_forward_optimize
 
 __all__ = [
     "add_features",
@@ -12,4 +13,6 @@ __all__ = [
     "RiskManager",
     "load_config",
     "setup_logging",
+    "rolling_windows",
+    "walk_forward_optimize",
 ]

--- a/botml/walkforward.py
+++ b/botml/walkforward.py
@@ -1,0 +1,56 @@
+"""Walk-forward optimization utilities."""
+
+from typing import Dict, Iterable, Tuple, List
+
+import pandas as pd
+from sklearn.base import BaseEstimator, clone
+from sklearn.metrics import accuracy_score
+import pickle
+
+
+def rolling_windows(df: pd.DataFrame, train_size: int, test_size: int) -> Iterable[Tuple[pd.DataFrame, pd.DataFrame]]:
+    """Yield rolling train/test splits."""
+    if train_size <= 0 or test_size <= 0:
+        raise ValueError("train_size and test_size must be positive")
+    n = len(df)
+    for start in range(0, n - train_size - test_size + 1, test_size):
+        train = df.iloc[start : start + train_size]
+        test = df.iloc[start + train_size : start + train_size + test_size]
+        yield train.reset_index(drop=True), test.reset_index(drop=True)
+
+
+def walk_forward_optimize(
+    df: pd.DataFrame,
+    features: List[str],
+    label_col: str,
+    models: Dict[str, BaseEstimator],
+    train_size: int,
+    test_size: int,
+    export_path: str = "best_model.pkl",
+) -> Tuple[str, float, Dict[str, List[float]]]:
+    """Evaluate models on rolling windows and save the best performer."""
+    if not models:
+        raise ValueError("models dictionary is empty")
+
+    metrics: Dict[str, List[float]] = {name: [] for name in models}
+
+    for train_df, test_df in rolling_windows(df, train_size, test_size):
+        X_train, y_train = train_df[features], train_df[label_col]
+        X_test, y_test = test_df[features], test_df[label_col]
+        for name, model in models.items():
+            m = clone(model)
+            m.fit(X_train, y_train)
+            preds = m.predict(X_test)
+            acc = accuracy_score(y_test, preds)
+            metrics[name].append(acc)
+
+    avg = {name: sum(vals) / len(vals) for name, vals in metrics.items()}
+    best_name = max(avg, key=avg.get)
+
+    best_model = clone(models[best_name])
+    best_model.fit(df[features], df[label_col])
+
+    with open(export_path, "wb") as fh:
+        pickle.dump(best_model, fh)
+
+    return best_name, avg[best_name], metrics

--- a/tests/test_walkforward.py
+++ b/tests/test_walkforward.py
@@ -1,0 +1,45 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import numpy as np
+from sklearn.dummy import DummyClassifier
+from sklearn.linear_model import LogisticRegression
+
+from botml.walkforward import rolling_windows, walk_forward_optimize
+
+
+def make_df(n=60):
+    rng = np.random.default_rng(0)
+    f1 = rng.standard_normal(n)
+    df = pd.DataFrame({'f1': f1})
+    df['label'] = (df['f1'] > 0).astype(int)
+    return df
+
+
+def test_rolling_windows_counts():
+    df = make_df()
+    windows = list(rolling_windows(df, train_size=10, test_size=5))
+    assert len(windows) == 10
+    for train, test in windows:
+        assert len(train) == 10
+        assert len(test) == 5
+
+
+def test_walk_forward_optimize_selects_best(tmp_path):
+    df = make_df()
+    models = {
+        'dummy': DummyClassifier(strategy='most_frequent'),
+        'lr': LogisticRegression(max_iter=1000, solver='liblinear'),
+    }
+    export = tmp_path / 'best.pkl'
+    best, score, metrics = walk_forward_optimize(
+        df,
+        features=['f1'],
+        label_col='label',
+        models=models,
+        train_size=10,
+        test_size=5,
+        export_path=str(export),
+    )
+    assert best == 'lr'
+    assert 'dummy' in metrics and 'lr' in metrics
+    assert export.exists()


### PR DESCRIPTION
## Summary
- add `botml.walkforward` with utilities for rolling window splits
- expose new functions in package init
- test walk-forward logic with scikit-learn models

## Testing
- `pip install pandas scikit-learn -q`
- `pip install pyyaml -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861c399abf8833188b51ca0f72fa20c