### PR TITLE
Add manual trade closure logic

### DIFF
--- a/tests/test_realtime_loop.py
+++ b/tests/test_realtime_loop.py
@@ -1,0 +1,40 @@
+import json
+import pandas as pd
+
+from live_trading import LiveTrader
+from tests.test_risk import MockClient
+from realtime_loop import check_manual_closures
+
+
+def test_manual_close_stop(tmp_path, caplog):
+    client = MockClient()
+    open_file = tmp_path / "trades.json"
+    trader = LiveTrader("BTCUSDT", 10000, client=client, open_trades_file=str(open_file))
+
+    trade = trader.open_trade(100, direction="long")
+    row = pd.Series({"close": 99.0, "high": 100.0, "low": 98.5})
+
+    with caplog.at_level("INFO"):
+        check_manual_closures(trader, row)
+
+    assert trade not in trader.open_trades
+    with open(open_file) as fh:
+        data = json.load(fh)
+    assert data == []
+    assert "stop" in caplog.text
+
+
+def test_manual_close_take_profit(tmp_path):
+    client = MockClient()
+    open_file = tmp_path / "trades.json"
+    trader = LiveTrader("BTCUSDT", 10000, client=client, open_trades_file=str(open_file))
+
+    trade = trader.open_trade(100, direction="long")
+    row = pd.Series({"close": 103.0, "high": 103.0, "low": 100.0})
+
+    check_manual_closures(trader, row)
+
+    assert trade not in trader.open_trades
+    with open(open_file) as fh:
+        data = json.load(fh)
+    assert data == []


### PR DESCRIPTION
## Summary
- check active trades on each cycle and close them if stop loss or take profit levels are hit
- log the reason for the manual close
- test manual closures of stop loss and take profit

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e216ca0083319e417cb217fd2b91