### PR TITLE
Implement drawdown pause state in LiveTrader

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Important fields include:
 - `symbols` – trading pairs to fetch, empty to auto‑select the top symbols.
 - `api_key`/`api_secret` – required for live trading.
 - `equity_curve_file` and `open_trades_file` – files the dashboard reads.
+- `paused_file` – state file used to disable trading when drawdown limits are hit.
 - `commission_pct` – percentage fee applied on each trade side during backtests.
 - Logging options such as `log_file`, `log_rotation` and `log_format`.
 - `retry_attempts` and `retry_backoff` for network retries.
@@ -203,6 +204,10 @@ trader = LiveTrader(
 trader.open_trade(price=30000, direction='long', bracket=True)
 ```
 
+If the account equity drops below the allowed drawdown the trader
+automatically writes a paused flag to `paused_file` and will refuse to
+open new trades until `reset_pause()` is called.
+
 Calling ``open_trade`` with ``bracket=True`` places stop-loss and
 take-profit orders using the configured ``RiskManager``. Trade size is
 computed automatically from the ``PositionSizer`` and ``account_size``.
@@ -217,7 +222,8 @@ streamlit run dashboard.py
 
 Then open the displayed URL in your browser (usually
 `http://localhost:8501`). The dashboard reads the files defined in
-`config.yaml` (`equity_curve_file`, `open_trades_file` and `log_file`).
+`config.yaml` (`equity_curve_file`, `open_trades_file`, `paused_file` and
+`log_file`).
 
 ### Alert configuration
 

--- a/config.yaml
+++ b/config.yaml
@@ -31,6 +31,8 @@ api_secret: ""
 equity_curve_file: equity_curve.csv
 # File containing currently open trades from LiveTrader
 open_trades_file: open_trades.json
+# File storing paused state when drawdown limits are hit
+paused_file: paused.json
 # Commission per trade side (e.g. 0.001 = 0.1%)
 commission_pct: 0.001
 

--- a/realtime_loop.py
+++ b/realtime_loop.py
@@ -82,6 +82,16 @@ def trading_cycle(symbol: str, trader: LiveTrader) -> None:
     if df.empty:
         LOGGER.warning("No data to process for %s", symbol)
         return
+    equity_path = Path(CONFIG.get("equity_curve_file", "equity_curve.csv"))
+    if equity_path.exists():
+        try:
+            eq = pd.read_csv(equity_path)["equity"].iloc[-1]
+            trader.update_equity(float(eq))
+        except Exception:
+            LOGGER.warning("Failed to read equity from %s", equity_path)
+    if trader.paused:
+        LOGGER.info("Trading is paused - skipping signal evaluation")
+        return
     model = load_model(symbol)
     feat_cols = [c for c in df.columns if c not in {"open_time", "label"}]
     last_row = df.iloc[-1]


### PR DESCRIPTION
## Summary
- add support for a paused state in `LiveTrader`
- persist pause information and allow manual reset
- prevent new trades when paused and update equity in realtime loop
- document new `paused_file` config option
- test pausing behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e34fdbd48331a576985272eb6ecf