### PR TITLE
Add multi-symbol backtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,23 @@ backtester = Backtester(
 equity = backtester.run()
 ```
 
+For multiple trading pairs use ``MultiPairBacktester`` from the ``backtest``
+package. Provide a dictionary of DataFrames keyed by symbol and a strategy
+function that receives each row and symbol name:
+
+```python
+from backtest.engine import MultiPairBacktester
+
+data = {"BTCUSDT": btc_df, "ETHUSDT": eth_df}
+
+def strategy(row, symbol):
+    # very naive example
+    return "long" if row.name == 0 else None
+
+bt = MultiPairBacktester(data, strategy, initial_capital=1000, risk_per_trade=0.01)
+equity = bt.run()
+```
+
 ## Orchestrator
 
 The `orchestrator.py` script automates the full workflow—data download,

--- a/backtest/__init__.py
+++ b/backtest/__init__.py
@@ -1,0 +1,16 @@
+"""Backtesting package providing portfolio utilities and engine."""
+
+from .engine import MultiPairBacktester
+from .portfolio import Portfolio
+from .trade import Trade
+from .metrics import compute_metrics
+from .walkforward import rolling_windows, walk_forward
+
+__all__ = [
+    "MultiPairBacktester",
+    "Portfolio",
+    "Trade",
+    "compute_metrics",
+    "rolling_windows",
+    "walk_forward",
+]

--- a/backtest/engine.py
+++ b/backtest/engine.py
@@ -1,0 +1,116 @@
+"""Engine for backtesting multiple symbols simultaneously."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Iterable, Optional
+from datetime import datetime
+
+import pandas as pd
+
+from .portfolio import Portfolio
+from .trade import Trade
+
+
+class MultiPairBacktester:
+    """Iterate over historical data for multiple symbols."""
+
+    def __init__(
+        self,
+        data: Dict[str, pd.DataFrame],
+        strategy: Callable[[pd.Series, str], Optional[str]],
+        initial_capital: float = 1000.0,
+        risk_per_trade: float = 0.01,
+        min_notional: float = 0.0,
+        commission_pct: float = 0.0,
+    ):
+        self.data = {s: df.reset_index(drop=True) for s, df in data.items()}
+        self.strategy = strategy
+        self.portfolio = Portfolio(initial_capital, risk_per_trade)
+        self.min_notional = min_notional
+        self.commission_pct = commission_pct
+        self.equity_curve = [initial_capital]
+        self.trades: Dict[str, list[Trade]] = {s: [] for s in data}
+        self.open_trades: Dict[str, Trade] = {}
+
+    def _close_trade(self, symbol: str, index: int, price: float, reason: str):
+        trade = self.open_trades.pop(symbol)
+        trade.exit_index = index
+        trade.exit_time = datetime.utcnow()
+        trade.exit_price = price
+        trade.reason = reason
+        fee = (trade.entry_price + price) * trade.size * self.commission_pct
+        trade.fees = fee
+        pnl = (
+            price - trade.entry_price
+            if trade.direction == "long"
+            else trade.entry_price - price
+        ) * trade.size - fee
+        self.portfolio.update_equity(pnl)
+        self.trades[symbol].append(trade)
+        self.equity_curve.append(self.portfolio.equity)
+
+    def run(self) -> float:
+        max_len = max(len(df) for df in self.data.values())
+        for i in range(max_len):
+            for symbol, df in self.data.items():
+                if i >= len(df):
+                    continue
+                row = df.iloc[i]
+                price = float(row["close"])
+                high = float(row.get("high", price))
+                low = float(row.get("low", price))
+
+                trade = self.open_trades.get(symbol)
+                if trade:
+                    if trade.direction == "long":
+                        if low <= trade.stop:
+                            self._close_trade(symbol, i, trade.stop, "stop")
+                            continue
+                        if high >= trade.take_profit:
+                            self._close_trade(symbol, i, trade.take_profit, "take_profit")
+                            continue
+                    else:
+                        if high >= trade.stop:
+                            self._close_trade(symbol, i, trade.stop, "stop")
+                            continue
+                        if low <= trade.take_profit:
+                            self._close_trade(symbol, i, trade.take_profit, "take_profit")
+                            continue
+
+                if symbol not in self.open_trades:
+                    signal = self.strategy(row, symbol)
+                    if signal in {"long", "short"}:
+                        size = self.portfolio.position_size(price)
+                        if size * price < self.min_notional:
+                            continue
+                        stop = price * (1 - self.portfolio.stop_loss_pct)
+                        take = price * (1 + self.portfolio.take_profit_pct)
+                        if signal == "short":
+                            stop = price * (1 + self.portfolio.stop_loss_pct)
+                            take = price * (1 - self.portfolio.take_profit_pct)
+                        trade = Trade(
+                            symbol=symbol,
+                            direction=signal,
+                            entry_index=i,
+                            entry_time=datetime.utcnow(),
+                            entry_price=price,
+                            size=size,
+                            stop=stop,
+                            take_profit=take,
+                        )
+                        self.open_trades[symbol] = trade
+
+            self.equity_curve.append(self.portfolio.equity)
+
+        for symbol in list(self.open_trades):
+            trade = self.open_trades[symbol]
+            df = self.data[symbol]
+            price = float(df.iloc[-1]["close"])
+            self._close_trade(symbol, len(df) - 1, price, "end")
+
+        return self.portfolio.equity
+
+    def all_trades(self) -> Iterable[Trade]:
+        for trades in self.trades.values():
+            for t in trades:
+                yield t

--- a/backtest/metrics.py
+++ b/backtest/metrics.py
@@ -1,0 +1,33 @@
+"""Performance metrics utilities."""
+
+from __future__ import annotations
+
+from typing import Iterable, Dict
+import math
+import pandas as pd
+
+from .trade import Trade
+
+
+def compute_metrics(trades: Iterable[Trade], equity_curve: Iterable[float]) -> Dict[str, float]:
+    trades = list(trades)
+    equity = list(equity_curve)
+    profits = [t.pnl() for t in trades if t.pnl() > 0]
+    losses = [t.pnl() for t in trades if t.pnl() < 0]
+    total_pnl = equity[-1] - equity[0] if equity else 0.0
+    win_rate = len(profits) / len(trades) if trades else 0.0
+    profit_factor = sum(profits) / abs(sum(losses)) if losses else float('inf')
+    returns = pd.Series(equity).pct_change().dropna()
+    if not returns.empty:
+        sharpe = returns.mean() / returns.std() * math.sqrt(len(returns))
+    else:
+        sharpe = 0.0
+    cum = pd.Series(equity).cummax()
+    drawdown = (pd.Series(equity) - cum).min()
+    return {
+        "pnl": total_pnl,
+        "win_rate": win_rate,
+        "profit_factor": profit_factor,
+        "max_drawdown": drawdown,
+        "sharpe": sharpe,
+    }

--- a/backtest/portfolio.py
+++ b/backtest/portfolio.py
@@ -1,0 +1,26 @@
+"""Simple portfolio utilities for capital allocation."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Portfolio:
+    """Manage account equity and risk sizing."""
+
+    equity: float
+    risk_per_trade: float = 0.01
+    stop_loss_pct: float = 0.01
+    take_profit_pct: float = 0.02
+
+    def position_size(self, entry_price: float) -> float:
+        """Return trade size based on risk per trade and stop loss."""
+        risk_amount = self.equity * self.risk_per_trade
+        stop_price = entry_price * (1 - self.stop_loss_pct)
+        risk_per_unit = abs(entry_price - stop_price)
+        if risk_per_unit <= 0:
+            raise ValueError("Stop price must differ from entry price")
+        size = risk_amount / risk_per_unit
+        return size
+
+    def update_equity(self, pnl: float):
+        self.equity += pnl

--- a/backtest/report.py
+++ b/backtest/report.py
@@ -1,0 +1,36 @@
+"""Reporting utilities for backtest results."""
+
+from __future__ import annotations
+
+import csv
+import json
+from typing import Iterable
+
+from .trade import Trade
+from .metrics import compute_metrics
+
+
+def report_console(trades: Iterable[Trade], equity_curve: Iterable[float]):
+    metrics = compute_metrics(trades, equity_curve)
+    for k, v in metrics.items():
+        print(f"{k}: {v}")
+
+
+def report_csv(trades: Iterable[Trade], path: str):
+    fields = list(Trade.__dataclass_fields__)
+    with open(path, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        for t in trades:
+            writer.writerow({f: getattr(t, f) for f in fields})
+
+
+def report_json(trades: Iterable[Trade], equity_curve: Iterable[float], path: str):
+    metrics = compute_metrics(trades, equity_curve)
+    data = {
+        "metrics": metrics,
+        "trades": [t.__dict__ for t in trades],
+        "equity_curve": list(equity_curve),
+    }
+    with open(path, "w") as fh:
+        json.dump(data, fh)

--- a/backtest/trade.py
+++ b/backtest/trade.py
@@ -1,0 +1,32 @@
+"""Trade data container used by the backtester."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Trade:
+    symbol: str
+    direction: str
+    entry_index: int
+    entry_time: datetime
+    entry_price: float
+    size: float
+    stop: float
+    take_profit: float
+    exit_index: Optional[int] = None
+    exit_time: Optional[datetime] = None
+    exit_price: Optional[float] = None
+    fees: float = 0.0
+    reason: Optional[str] = None
+
+    def pnl(self) -> float:
+        if self.exit_price is None:
+            return 0.0
+        diff = (
+            self.exit_price - self.entry_price
+            if self.direction == "long"
+            else self.entry_price - self.exit_price
+        )
+        return diff * self.size - self.fees

--- a/backtest/utils.py
+++ b/backtest/utils.py
@@ -1,0 +1,18 @@
+"""Helper routines for backtesting."""
+
+from datetime import datetime
+from typing import Any
+
+import pandas as pd
+
+
+def parse_date(s: str) -> datetime:
+    return pd.to_datetime(s).to_pydatetime()
+
+
+def to_timestamp(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def log(msg: str):
+    print(msg)

--- a/backtest/walkforward.py
+++ b/backtest/walkforward.py
@@ -1,0 +1,25 @@
+"""Walk-forward training/testing utilities for backtesting."""
+
+from __future__ import annotations
+from typing import Iterable, Tuple
+
+import pandas as pd
+
+
+def rolling_windows(df: pd.DataFrame, train: int, test: int) -> Iterable[Tuple[pd.DataFrame, pd.DataFrame]]:
+    if train <= 0 or test <= 0:
+        raise ValueError("train and test sizes must be positive")
+    n = len(df)
+    for start in range(0, n - train - test + 1, test):
+        train_df = df.iloc[start : start + train].reset_index(drop=True)
+        test_df = df.iloc[start + train : start + train + test].reset_index(drop=True)
+        yield train_df, test_df
+
+
+def walk_forward(df: pd.DataFrame, train: int, test: int, fit_func, eval_func) -> float:
+    scores = []
+    for train_df, test_df in rolling_windows(df, train, test):
+        model = fit_func(train_df)
+        score = eval_func(model, test_df)
+        scores.append(score)
+    return sum(scores) / len(scores)

--- a/run_backtest.py
+++ b/run_backtest.py
@@ -1,0 +1,39 @@
+"""Command line interface to run MultiPairBacktester."""
+
+import argparse
+import pandas as pd
+
+from backtest.engine import MultiPairBacktester
+from backtest.report import report_console
+
+
+def main():
+    p = argparse.ArgumentParser(description="Run backtest")
+    p.add_argument("--symbols", nargs="+", required=True)
+    p.add_argument("--csv", nargs="+", required=True, help="CSV files per symbol")
+    p.add_argument("--capital", type=float, default=1000.0)
+    p.add_argument("--risk", type=float, default=0.01, help="Risk per trade")
+    p.add_argument("--min_notional", type=float, default=0.0)
+    p.add_argument("--commission", type=float, default=0.0)
+    args = p.parse_args()
+
+    data = {sym: pd.read_csv(path) for sym, path in zip(args.symbols, args.csv)}
+
+    def strat(row, symbol):
+        return "long" if row.name == 0 else None
+
+    bt = MultiPairBacktester(
+        data,
+        strat,
+        initial_capital=args.capital,
+        risk_per_trade=args.risk,
+        min_notional=args.min_notional,
+        commission_pct=args.commission,
+    )
+    equity = bt.run()
+    report_console(list(bt.all_trades()), bt.equity_curve)
+    print(f"final_equity: {equity}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backtest_engine.py
+++ b/tests/test_backtest_engine.py
@@ -1,0 +1,43 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+
+from backtest.engine import MultiPairBacktester
+
+
+def make_data():
+    df1 = pd.DataFrame({
+        'close': [1.0, 1.2, 1.3],
+        'high': [1.0, 1.2, 1.3],
+        'low': [1.0, 1.2, 1.3],
+    })
+    df2 = pd.DataFrame({
+        'close': [2.0, 2.1, 2.2],
+        'high': [2.0, 2.1, 2.2],
+        'low': [2.0, 2.1, 2.2],
+    })
+    return {'A': df1, 'B': df2}
+
+
+def test_min_notional_blocks_trade():
+    data = make_data()
+
+    def strat(row, symbol):
+        return 'long' if row.name == 0 else None
+
+    bt = MultiPairBacktester(data, strat, initial_capital=1000, min_notional=1e6)
+    equity = bt.run()
+    assert equity == 1000
+    assert list(bt.all_trades()) == []
+
+
+def test_backtester_runs_trades():
+    data = make_data()
+
+    def strat(row, symbol):
+        return 'long' if row.name == 0 else None
+
+    bt = MultiPairBacktester(data, strat, initial_capital=1000, risk_per_trade=0.1)
+    equity = bt.run()
+    trades = list(bt.all_trades())
+    assert len(trades) == 2
+    assert equity > 1000

--- a/tests/test_backtest_metrics.py
+++ b/tests/test_backtest_metrics.py
@@ -1,0 +1,27 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from datetime import datetime
+from backtest.trade import Trade
+from backtest.metrics import compute_metrics
+
+
+def make_trades():
+    t1 = Trade('A', 'long', 0, datetime.utcnow(), 1.0, 1, 0.9, 1.1)
+    t1.exit_index = 1
+    t1.exit_time = datetime.utcnow()
+    t1.exit_price = 1.1
+    t1.fees = 0
+    t2 = Trade('A', 'long', 0, datetime.utcnow(), 1.0, 1, 0.9, 1.1)
+    t2.exit_index = 1
+    t2.exit_time = datetime.utcnow()
+    t2.exit_price = 0.95
+    t2.fees = 0
+    return [t1, t2]
+
+
+def test_compute_metrics_basic():
+    trades = make_trades()
+    equity = [1000, 1010, 1005]
+    metrics = compute_metrics(trades, equity)
+    assert metrics['pnl'] == 5
+    assert metrics['win_rate'] == 0.5
+    assert metrics['profit_factor'] > 1

--- a/tests/test_backtest_walkforward.py
+++ b/tests/test_backtest_walkforward.py
@@ -1,0 +1,31 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+from backtest.walkforward import rolling_windows, walk_forward
+
+
+def make_df(n=30):
+    df = pd.DataFrame({'x': range(n), 'y': [0 if i % 2 == 0 else 1 for i in range(n)]})
+    return df
+
+
+def test_rolling_windows_counts():
+    df = make_df(20)
+    windows = list(rolling_windows(df, train=5, test=5))
+    assert len(windows) == 3
+    for tr, te in windows:
+        assert len(tr) == 5
+        assert len(te) == 5
+
+
+def test_walk_forward_average():
+    df = make_df(20)
+
+    def fit(train_df):
+        mean = train_df['y'].mean()
+        return mean
+
+    def eval_fn(model, test_df):
+        return abs(model - test_df['y'].mean())
+
+    score = walk_forward(df, 5, 5, fit, eval_fn)
+    assert score >= 0


### PR DESCRIPTION
## Summary
- implement `backtest/` package with portfolio, trade, engine, metrics, reporting and helpers
- add walk-forward utilities and CLI script
- document usage of `MultiPairBacktester` in README
- include unit tests for new modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f2f61e088331829d30fe6de63790