### PR TITLE
Support custom labeling config

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -28,9 +28,12 @@ def load_price_data(db_path: str, symbol: str) -> pd.DataFrame:
     return df
 
 
-def generate_features_and_labels(df: pd.DataFrame) -> pd.DataFrame:
+def generate_features_and_labels(config: dict, df: pd.DataFrame) -> pd.DataFrame:
+    """Add features and labels using configuration options."""
+    horizon = int(config.get("label_horizon", 5))
+    threshold = float(config.get("label_threshold", 0.002))
     df = add_features(df)
-    df = create_labels(df)
+    df = create_labels(df, horizon=horizon, threshold=threshold)
     return df
 
 
@@ -114,7 +117,7 @@ def main():
     data: Dict[str, pd.DataFrame] = {}
     for sym in symbols:
         df = load_price_data(db_path, sym)
-        df = generate_features_and_labels(df)
+        df = generate_features_and_labels(config, df)
         data[sym] = df
 
     train_df = pd.concat(data.values(), ignore_index=True)

--- a/tests/test_generate_features_and_labels.py
+++ b/tests/test_generate_features_and_labels.py
@@ -1,0 +1,28 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import numpy as np
+
+import orchestrator
+
+
+def make_df(n=60):
+    base = np.linspace(1, 1.6, n)
+    return pd.DataFrame({
+        "open_time": pd.date_range("2024-01-01", periods=n, freq="min"),
+        "open": base,
+        "high": base + 0.01,
+        "low": base - 0.01,
+        "close": base,
+        "volume": np.linspace(100, 200, n),
+    })
+
+
+def test_generate_features_and_labels_custom_config():
+    df = make_df()
+    cfg = {"label_horizon": 1, "label_threshold": 0.005}
+    labeled = orchestrator.generate_features_and_labels(cfg, df)
+    assert labeled["label"].sum() > 0
+
+    cfg_far = {"label_horizon": 5, "label_threshold": 0.1}
+    labeled_far = orchestrator.generate_features_and_labels(cfg_far, make_df())
+    assert labeled["label"].sum() > labeled_far["label"].sum()


### PR DESCRIPTION
## Summary
- allow passing configuration to `generate_features_and_labels`
- read label horizon and threshold from config
- update orchestrator and research loop usages
- test that custom horizon/threshold are honored

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864480faae48331b0699ca11ae884c2