### PR TITLE
Add integration tests for CLI scripts

### DIFF
--- a/tests/test_hyperoptimize.py
+++ b/tests/test_hyperoptimize.py
@@ -1,0 +1,12 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import numpy as np
+import hyperoptimize
+
+
+def test_optimize_model_returns_estimator(monkeypatch):
+    df = pd.DataFrame({'close': np.linspace(1, 2, 20)})
+    monkeypatch.setattr(hyperoptimize, 'load_data', lambda: df)
+    model = hyperoptimize.optimize_model()
+    assert hasattr(model, 'predict')
+    assert hasattr(model, 'n_features_in_')

--- a/tests/test_research_loop.py
+++ b/tests/test_research_loop.py
@@ -1,0 +1,35 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import pandas as pd
+import research_loop
+
+
+class LoopStop(Exception):
+    pass
+
+
+def test_research_loop_creates_output(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(research_loop.bot, 'download_and_store_all', lambda: None)
+    monkeypatch.setattr(research_loop, 'load_config', lambda: {'update_interval': 1, 'symbols': ['BTCUSDT']})
+    df = pd.DataFrame({'close': [1, 1.1], 'label': [0, 1], 'feat': [0.1, 0.2]})
+    monkeypatch.setattr(research_loop, 'load_price_data', lambda db, sym: df)
+    monkeypatch.setattr(research_loop, 'generate_features_and_labels', lambda cfg, d: d)
+
+    class DummyModel:
+        def predict(self, X):
+            return [0] * len(X)
+    monkeypatch.setattr(research_loop, 'train_random_forest', lambda df, path: DummyModel())
+    monkeypatch.setattr(research_loop, 'backtest_model', lambda data, model, commission_pct=0.0: (1000.0, {'pnl': 1.0}, []))
+
+    def fake_sleep(x):
+        raise LoopStop()
+    monkeypatch.setattr(research_loop.time, 'sleep', fake_sleep)
+
+    try:
+        research_loop.main_loop()
+    except LoopStop:
+        pass
+
+    assert (tmp_path / 'predictions.json').is_file()
+    assert (tmp_path / 'metrics.json').is_file()

--- a/tests/test_run_backtest.py
+++ b/tests/test_run_backtest.py
@@ -1,0 +1,16 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from pathlib import Path
+import pandas as pd
+import run_backtest
+
+
+def test_run_backtest_outputs_equity(tmp_path, capsys, monkeypatch):
+    csv_path = tmp_path / 'btc.csv'
+    df = pd.DataFrame({'close': [1, 1.1, 1.2], 'high': [1, 1.1, 1.2], 'low': [1, 1, 1]})
+    df.to_csv(csv_path, index=False)
+    monkeypatch.setattr(sys, 'argv', ['run_backtest.py', '--symbols', 'BTCUSDT', '--csv', str(csv_path)])
+    run_backtest.main()
+    out = capsys.readouterr().out
+    assert 'final_equity:' in out
+    value = float(out.strip().split(':')[-1])
+    assert value > 0

--- a/tests/test_train_model.py
+++ b/tests/test_train_model.py
@@ -1,0 +1,32 @@
+import os, sys; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import io
+import importlib.util
+from pathlib import Path
+import sqlite3
+import pandas as pd
+
+
+def test_train_model_creates_file(tmp_path, monkeypatch):
+    db = tmp_path / "data.db"
+    df = pd.DataFrame({'open_time': range(20), 'close': range(20)})
+    with sqlite3.connect(db) as conn:
+        df.to_sql('_BTCUSDT', conn, index=False)
+
+    config_yaml = f"database_path: {db}\nsymbols: ['BTCUSDT']\n"
+    module_path = Path(__file__).resolve().parents[1] / 'train_model.py'
+    config_path = module_path.parent / 'config.yaml'
+    open_orig = open
+
+    def fake_open(path, *args, **kwargs):
+        if Path(path).resolve() == config_path.resolve():
+            return io.StringIO(config_yaml)
+        return open_orig(path, *args, **kwargs)
+
+    monkeypatch.setattr('builtins.open', fake_open)
+    monkeypatch.chdir(tmp_path)
+
+    spec = importlib.util.spec_from_file_location('train_model', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert Path('rf_btcusdt.pkl').is_file()


### PR DESCRIPTION
## Summary
- add unit tests for optimize_model, train_model script, run_backtest CLI, and research_loop
- ensure temporary files used and outputs verified

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68645d456c2883318f32d7e3101152f5