### PR TITLE
Align pytest command across docs and CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,4 +19,4 @@ jobs:
           pip install -r requirements.txt
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
       - name: Run tests
-        run: pytest -q
+        run: pytest --maxfail=1 --disable-warnings

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Install the runtime dependencies using the provided requirements file:
 pip install -r requirements.txt
 ```
 
-To run the unit tests, also install the development requirements and execute `pytest`:
+To run the unit tests, also install the development requirements and execute `pytest` with the recommended flags:
 
 ```bash
 pip install -r requirements-dev.txt  # adds pytest and helpers
-pytest -q
+pytest --maxfail=1 --disable-warnings
 ```
 
 ## Usage

--- a/RUNNING.md
+++ b/RUNNING.md
@@ -1,6 +1,12 @@
 Install dependencies with `pip install -r requirements.txt`.
 Use `pip install -r requirements-dev.txt` to add the testing tools.
 
+Run the test suite with:
+
+```
+pytest --maxfail=1 --disable-warnings
+```
+
 Run the downloader:
 
 ```


### PR DESCRIPTION
## Summary
- run `pytest --maxfail=1 --disable-warnings` in CI
- document same command in README
- mention test command in RUNNING guide

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6864650a78388331a754a73557729c06