### PR TITLE
Add configurable cycle sleep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,8 @@ Manejo avanzado de errores y reconexión automática en todas las conexiones con
 
 Persistencia de estado: el bot debe guardar su estado (último modelo, posiciones, histórico de señales, parámetros) para poder recuperarse exactamente donde quedó después de un crash o reinicio.
 
+Intervalo de ciclo configurable: la clave `cycle_sleep` en `config.yaml` define en segundos la pausa entre iteraciones del loop principal.
+
 2. Entrenamiento y Evolución Autónoma
 Entrenamiento automático y periódico del modelo (por tiempo, cantidad de trades o performance).
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,3 +6,4 @@ mode: live   # live | test | backtest
 log_level: INFO
 log_file: bot.log
 watchdog_timeout: 120
+cycle_sleep: 60

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from backtest.engine import Backtester
 from dashboard.dashboard import Dashboard
 from logging_utils.logging import setup_logging
 from watchdog.watchdog import Watchdog
+import time
 
 import yaml
 
@@ -41,6 +42,7 @@ def main():
         if model_manager.need_retrain():
             model_manager.retrain(feed.history())
         dashboard.update(trader.stats(), model_manager.stats())
+        time.sleep(config.get("cycle_sleep", 60))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- allow a delay between iterations via `cycle_sleep`
- document new `cycle_sleep` option in `config.yaml` and AGENTS guidelines

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68653db9e18c8331b98b0b785ea1321b