### PR TITLE
Add retry logic with timeout for Binance fetch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,5 @@ log_level: INFO
 log_file: bot.log
 watchdog_timeout: 120
 cycle_sleep: 60
+download_retries: 3
+request_timeout: 10


### PR DESCRIPTION
## Summary
- support retries and timeout when requesting Binance klines
- configure number of retries and request timeout

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68653ebd25f0833182f155d055c2e73c