### PR TITLE
Add API credential placeholders

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,14 @@ Herramientas de análisis automático de errores y eventos para aprender del pas
 * **Revisa dependencias:** Mantén `requirements.txt` actualizado y libre de vulnerabilidades conocidas.
 * **Logs limpios:** Filtra cualquier información sensible antes de loggear.
 
+### Configuración de credenciales
+
+Los campos `api_key` y `api_secret` en `config.yaml` son solo marcadores. Coloca
+las credenciales reales en un archivo `.env` en la raíz con las claves `API_KEY`
+y `API_SECRET`, o bien expórtalas como variables de entorno antes de ejecutar el
+bot. Los módulos `Trader` y `DataFeed` leerán esas variables priorizándolas
+sobre el archivo de configuración.
+
 ---
 
 ## Mantenimiento y Escalabilidad

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,6 @@
 api_url: https://api.binance.com
+api_key: "YOUR_API_KEY"
+api_secret: "YOUR_API_SECRET"
 database_path: binance_1m.db
 symbols: [BTCUSDT, ETHUSDT]
 interval: '1m'

--- a/data_feed/downloader.py
+++ b/data_feed/downloader.py
@@ -1,5 +1,6 @@
 """Utilities for downloading and reading market data from Binance."""
 
+import os
 import requests
 import pandas as pd
 from datetime import datetime
@@ -24,6 +25,8 @@ class DataFeed:
         self.api_url = config["api_url"]
         self.symbols = config["symbols"]
         self.interval = config["interval"]
+        self.api_key = os.environ.get("API_KEY", config.get("api_key"))
+        self.api_secret = os.environ.get("API_SECRET", config.get("api_secret"))
         self.max_retries = config.get("download_retries", 3)
         self.timeout = config.get("request_timeout", 10)
 

--- a/trading/live.py
+++ b/trading/live.py
@@ -1,6 +1,9 @@
 """Live trading utilities for sending orders to an exchange."""
 
 
+import os
+
+
 class Trader:
     """Execute real trades on the configured exchange."""
 
@@ -17,6 +20,8 @@ class Trader:
 
         self.config = config
         self.logger = logger
+        self.api_key = os.environ.get("API_KEY", config.get("api_key"))
+        self.api_secret = os.environ.get("API_SECRET", config.get("api_secret"))
 
     def execute(self, signals):
         """Send trading orders for the provided signals."""


### PR DESCRIPTION
## Summary
- add placeholder `api_key` and `api_secret` entries in `config.yaml`
- load API credentials from environment in `DataFeed` and `Trader`
- document credential setup with `.env` or environment variables in `AGENTS.md`

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68654218a9348331a9deda4661a85d2e