### PR TITLE
Add dotenv integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ BotML is an automated intraday trading bot that aims to operate fully autonomous
 ```bash
 pip install -r requirements.txt
 ```
-Python 3.11 or newer is recommended.
+Python 3.11 or newer is recommended. The package list includes `python-dotenv` for reading configuration from a `.env` file.
 
 ## Configuration
 Edit `config.yaml` to adjust API endpoints, symbols and other runtime options. Real API credentials are **not** stored in the YAML file; create a `.env` file in the project root with:
@@ -17,6 +17,8 @@ API_KEY=your_key
 API_SECRET=your_secret
 ```
 These variables override the `api_key` and `api_secret` placeholders found in `config.yaml`. The key `cycle_sleep` controls the pause in seconds between trading cycles.
+
+If a `.env` file exists, the `DataFeed` and `Trader` classes automatically load it at startup using `python-dotenv`.
 
 ## Running the Bot
 Launch the bot with:

--- a/data_feed/downloader.py
+++ b/data_feed/downloader.py
@@ -4,6 +4,7 @@ import os
 import requests
 import pandas as pd
 from datetime import datetime
+from dotenv import load_dotenv
 
 
 class DataFeed:
@@ -22,6 +23,8 @@ class DataFeed:
 
         self.config = config
         self.logger = logger
+        if os.path.exists(".env"):
+            load_dotenv(".env")
         self.api_url = config["api_url"]
         self.symbols = config["symbols"]
         self.interval = config["interval"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyyaml
 joblib
 streamlit
 requests
+python-dotenv

--- a/tests/test_data_feed.py
+++ b/tests/test_data_feed.py
@@ -113,3 +113,23 @@ def test_update_creates_csv_from_request(tmp_path, memory_logger, monkeypatch):
     ]
     assert list(df.columns) == expected_cols
     assert df["symbol"].iloc[0] == "BBB"
+
+
+def test_env_file_overrides_config(tmp_path, memory_logger, monkeypatch):
+    """Environment variables from a .env file should override config values."""
+    logger, _ = memory_logger
+    env_path = tmp_path / ".env"
+    env_path.write_text("API_KEY=envkey\nAPI_SECRET=envsecret\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    config = {
+        "api_url": "",
+        "symbols": ["T"],
+        "interval": "1m",
+        "api_key": "cfg",
+        "api_secret": "cfg",
+    }
+    feed = DataFeed(config, logger)
+    assert feed.api_key == "envkey"
+    assert feed.api_secret == "envsecret"

--- a/trading/live.py
+++ b/trading/live.py
@@ -2,6 +2,7 @@
 
 
 import os
+from dotenv import load_dotenv
 
 
 class Trader:
@@ -20,6 +21,8 @@ class Trader:
 
         self.config = config
         self.logger = logger
+        if os.path.exists(".env"):
+            load_dotenv(".env")
         self.api_key = os.environ.get("API_KEY", config.get("api_key"))
         self.api_secret = os.environ.get("API_SECRET", config.get("api_secret"))
 


### PR DESCRIPTION
## Summary
- include `python-dotenv` in dependencies
- automatically load `.env` for `DataFeed` and `Trader`
- document env loading in README
- test that `.env` variables override config

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68656a731e5c8331bb6c621180075dc3