### PR TITLE
Handle empty dataframes in DataFeed.update

### DIFF
--- a/data_feed/downloader.py
+++ b/data_feed/downloader.py
@@ -42,8 +42,15 @@ class DataFeed:
 
         for symbol in self.symbols:
             df = self._fetch_binance_klines(symbol)
-            if not df.empty and "symbol" not in df.columns:
+            if df.empty:
+                self.logger.warning(
+                    f"No se recibieron velas para {symbol}; se omite guardado"
+                )
+                continue
+
+            if "symbol" not in df.columns:
                 df["symbol"] = symbol
+
             df.to_csv(f"{symbol}_{self.interval}.csv", index=False)
             self.logger.info(f"Actualizadas velas para {symbol}")
 

--- a/tests/test_data_feed.py
+++ b/tests/test_data_feed.py
@@ -115,6 +115,21 @@ def test_update_creates_csv_from_request(tmp_path, memory_logger, monkeypatch):
     assert df["symbol"].iloc[0] == "BBB"
 
 
+def test_update_skips_empty_dataframe(tmp_path, memory_logger, monkeypatch):
+    """DataFeed.update should not create a CSV when no data is returned."""
+    logger, _ = memory_logger
+    config = {"api_url": "", "symbols": ["EMPTY"], "interval": "1m"}
+    feed = DataFeed(config, logger)
+    monkeypatch.chdir(tmp_path)
+
+    monkeypatch.setattr(
+        DataFeed, "_fetch_binance_klines", lambda *a, **k: pd.DataFrame(), raising=False
+    )
+
+    feed.update()
+    assert not (tmp_path / "EMPTY_1m.csv").exists()
+
+
 def test_env_file_overrides_config(tmp_path, memory_logger, monkeypatch):
     """Environment variables from a .env file should override config values."""
     logger, _ = memory_logger


### PR DESCRIPTION
## Summary
- skip writing CSV files when update receives an empty dataframe
- ensure DataFeed.update is tested for skipping empty frames

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68656f209fc08331b47b9e350cef1a32