### PR TITLE
Handle missing Streamlit context

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ python main.py
 ```
 Ensure your `.env` file is in place so the bot can authenticate with the exchange.
 
+## Running the Dashboard
+Start the Streamlit interface in a separate process:
+```bash
+streamlit run dashboard/dashboard.py
+```
+When `main.py` runs without Streamlit, dashboard updates are skipped to avoid warning messages.
+
 ## Running Tests
 Use pytest to run the automated tests:
 ```bash

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -2,6 +2,12 @@
 
 import streamlit as st
 
+try:
+    from streamlit.runtime.scriptrunner import get_script_run_ctx
+except Exception:  # streamlit < 1.18 compatibility
+    def get_script_run_ctx() -> object:
+        return None
+
 
 class Dashboard:
     """Render metrics and charts in a Streamlit dashboard."""
@@ -14,6 +20,11 @@ class Dashboard:
 
     def update(self, trader_stats, model_stats):
         """Render the latest trader and model statistics."""
+        # Avoid warning when Streamlit is not running.
+        ctx = get_script_run_ctx()
+        if ctx is None:
+            self.logger.debug("Streamlit context missing; dashboard update skipped")
+            return
 
         st.title("Dashboard Bot Trading")
         st.write("Trader stats:", trader_stats)


### PR DESCRIPTION
## Summary
- avoid calling Streamlit when it's not running
- document how to run the dashboard separately

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_686571ffc71c8331881b3d5afc4755d5