### PR TITLE
Separate Streamlit dashboard from bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Start the Streamlit interface in a separate process:
 ```bash
 streamlit run dashboard/dashboard.py
 ```
-When `main.py` runs without Streamlit, dashboard updates are skipped to avoid warning messages.
+`main.py` writes metrics to `results.json`. The Streamlit dashboard reads this file to display the latest data.
 
 ## Running Tests
 Use pytest to run the automated tests:

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ from models.manager import ModelManager
 from trading.live import Trader
 from trading.simulation import Simulator
 from backtest.engine import Backtester
-from dashboard.dashboard import Dashboard
 from logging_utils.logging import setup_logging
 from watchdog.watchdog import Watchdog
 from strategy import StrategyVariant
@@ -13,6 +12,7 @@ from evolution import (
     save_population,
     load_population,
 )
+from modules.analytics import gather_metrics, save_metrics
 import time
 
 import yaml
@@ -31,7 +31,6 @@ def main():
     trader = Trader(config, logger)
     simulator = Simulator(config, logger)
     backtester = Backtester(config, logger)
-    dashboard = Dashboard(config, logger)
     watchdog = Watchdog(config, logger)
 
     population_path = config.get("population_path", "population.json")
@@ -68,7 +67,8 @@ def main():
             top_pct=selection_pct,
         )
         save_population(population, population_path)
-        dashboard.update(trader.stats(), model_manager.stats(), population)
+        metrics = gather_metrics(trader, model_manager, population)
+        save_metrics(metrics, "results.json")
         time.sleep(config.get("cycle_sleep", 60))
 
 if __name__ == "__main__":

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,0 +1,1 @@
+"""Shared helper modules."""

--- a/modules/analytics.py
+++ b/modules/analytics.py
@@ -1,0 +1,38 @@
+"""Utility functions for saving and loading bot metrics."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List, Dict
+
+from strategy import StrategyVariant
+
+
+def gather_metrics(trader: Any, model_manager: Any, variants: List[StrategyVariant] | None = None) -> Dict[str, Any]:
+    """Collect metrics from core components for serialization."""
+    data = {
+        "trader": trader.stats(),
+        "model": model_manager.stats(),
+    }
+    if variants:
+        data["variants"] = [
+            {
+                "gen": v.generation,
+                **v.params,
+                **(v.history[-1] if v.history else {}),
+            }
+            for v in variants
+        ]
+    return data
+
+
+def save_metrics(metrics: Dict[str, Any], path: str = "results.json") -> None:
+    """Write metrics to a JSON file."""
+    with open(path, "w") as f:
+        json.dump(metrics, f)
+
+
+def load_metrics(path: str = "results.json") -> Dict[str, Any]:
+    """Read metrics from a JSON file."""
+    with open(path) as f:
+        return json.load(f)


### PR DESCRIPTION
## Summary
- remove Dashboard integration from `main.py`
- add `modules.analytics` utilities for sharing metrics
- rewrite Streamlit UI in `dashboard/dashboard.py`
- document new workflow in README

## Testing
- `pip install pandas`
- `pip install requests`
- `pip install python-dotenv`
- `pip install scikit-learn`
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_686597ba94c08331966de82964b385d8