### PR TITLE
Make trade amount configurable and logged

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ API_KEY=your_key
 API_SECRET=your_secret
 ```
 These variables override the `api_key` and `api_secret` placeholders found in `config.yaml`. The key `cycle_sleep` controls the pause in seconds between trading cycles.
+The parameter `trade_size` defines the amount used for each trade.
 
 If a `.env` file exists, the `DataFeed` and `Trader` classes automatically load it at startup using `python-dotenv`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -15,3 +15,4 @@ population_path: population.json
 population_size: 4
 mutation_rate: 0.1
 selection_pct: 0.5
+trade_size: 10

--- a/models/manager.py
+++ b/models/manager.py
@@ -61,10 +61,11 @@ class ModelManager:
                     "symbol": df["symbol"][0],
                     "side": "BUY",
                     "score": 1.0,
+                    "amount": self.config.get("trade_size", 10),
                 }
                 signals.append(signal)
                 self.logger.info(
-                    f"Se\u00f1al detectada: {signal['symbol']} | Acci\u00f3n: {signal['side']} | Score: {signal['score']}"
+                    f"Se\u00f1al detectada: {signal['symbol']} | Acci\u00f3n: {signal['side']} | Score: {signal['score']} | Monto: {signal['amount']}"
                 )
         return signals
 

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -3,8 +3,8 @@ from trading.simulation import Simulator
 
 def test_simulator_logs_and_updates_balance(memory_logger):
     logger, stream = memory_logger
-    sim = Simulator({}, logger)
+    sim = Simulator({"trade_size": 1}, logger)
     start = sim.balance
-    sim.simulate([{"price": 100, "symbol": "T"}])
+    sim.simulate([{"price": 100, "symbol": "T", "side": "BUY"}])
     assert sim.balance < start
-    assert "Simulaci" in stream.getvalue()
+    assert "Modo: Simulado" in stream.getvalue()

--- a/trading/live.py
+++ b/trading/live.py
@@ -34,10 +34,13 @@ class Trader:
         for signal in signals:
             self.logger.info(f"Enviando orden real: {signal}")
             try:
+                trade_amount = signal.get("amount", self.config.get("trade_size", 10))
+                fill_price = float(signal.get("price", 0))
                 # Aquí implementas llamada a la API de Binance para crear orden
                 self.trades += 1
+                self.pnl -= trade_amount * fill_price
                 self.logger.info(
-                    f"Orden ejecutada: {signal['symbol']} | Resultado: OK | Precio: {signal.get('price', 'N/A')} | Qty: {signal.get('amount', 'N/A')}"
+                    f"Trade ejecutado | Modo: Real | Símbolo: {signal['symbol']} | Acción: {signal['side']} | Monto: {trade_amount} | Precio: {fill_price:.2f} | Score: {signal.get('score', 'n/a')} | Balance post-trade: {self.pnl:.2f}"
                 )
             except Exception as exc:
                 self.logger.error(f"ERROR al ejecutar orden: {exc}")

--- a/trading/simulation.py
+++ b/trading/simulation.py
@@ -26,10 +26,11 @@ class Simulator:
         """Process signals updating the virtual balance."""
 
         for signal in signals:
+            trade_amount = signal.get("amount", self.config.get("trade_size", 10))
             fill_price = self._simulate_slippage(signal)
-            self.balance -= fill_price * self.commission_pct
+            self.balance -= trade_amount * fill_price
             self.logger.info(
-                f"Simulación: {signal} ejecutada a {fill_price}, balance: {self.balance:.2f}"
+                f"Trade ejecutado | Modo: Simulado | Símbolo: {signal['symbol']} | Acción: {signal['side']} | Monto: {trade_amount} | Precio: {fill_price:.2f} | Score: {signal.get('score', 'n/a')} | Balance post-trade: {self.balance:.2f}"
             )
 
     def _simulate_slippage(self, signal):


### PR DESCRIPTION
## Summary
- add `trade_size` option in config
- document trade size in README
- include amount in generated signals
- use the amount in simulation and live trading
- improve trade logs
- update simulator test for new log output

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_68659f68fcbc8331b0fc435eba6b7833