### PR TITLE
Fix price usage and balance logic

### DIFF
--- a/models/manager.py
+++ b/models/manager.py
@@ -57,15 +57,22 @@ class ModelManager:
         signals = []
         for df in dfs:
             if not df.empty:
+                price = float(df["close"].astype(float).iloc[-1])
                 signal = {
-                    "symbol": df["symbol"][0],
+                    "symbol": df["symbol"].iloc[-1],
                     "side": "BUY",
                     "score": 1.0,
                     "amount": self.config.get("trade_size", 10),
+                    "price": price,
                 }
                 signals.append(signal)
                 self.logger.info(
-                    f"Se\u00f1al detectada: {signal['symbol']} | Acci\u00f3n: {signal['side']} | Score: {signal['score']} | Monto: {signal['amount']}"
+                    "Se\u00f1al detectada | Symbol: %s | Acci\u00f3n: %s | Score: %s | Monto: %s | Precio: %.2f",
+                    signal.get("symbol", "n/a"),
+                    signal.get("side", "n/a"),
+                    signal.get("score", "n/a"),
+                    signal.get("amount", "n/a"),
+                    signal.get("price", float("nan")),
                 )
         return signals
 

--- a/trading/live.py
+++ b/trading/live.py
@@ -32,18 +32,35 @@ class Trader:
         """Send trading orders for the provided signals."""
 
         for signal in signals:
-            self.logger.info(f"Enviando orden real: {signal}")
+            self.logger.info("Enviando orden real: %s", signal)
             try:
-                trade_amount = signal.get("amount", self.config.get("trade_size", 10))
+                trade_amount = signal.get("amount")
+                if trade_amount is None:
+                    self.logger.warning("Falta campo 'amount' en signal: %s", signal)
+                    trade_amount = self.config.get("trade_size", 10)
+                if "price" not in signal:
+                    self.logger.warning("Falta campo 'price' en signal: %s", signal)
                 fill_price = float(signal.get("price", 0))
+                side = signal.get("side")
                 # Aquí implementas llamada a la API de Binance para crear orden
                 self.trades += 1
-                self.pnl -= trade_amount * fill_price
+                if side == "BUY":
+                    self.pnl -= trade_amount * fill_price
+                elif side == "SELL":
+                    self.pnl += trade_amount * fill_price
+                else:
+                    self.logger.warning("Valor 'side' inválido en signal: %s", signal)
                 self.logger.info(
-                    f"Trade ejecutado | Modo: Real | Símbolo: {signal['symbol']} | Acción: {signal['side']} | Monto: {trade_amount} | Precio: {fill_price:.2f} | Score: {signal.get('score', 'n/a')} | Balance post-trade: {self.pnl:.2f}"
+                    "Trade ejecutado | Modo: Real | Símbolo: %s | Acción: %s | Monto: %s | Precio: %.2f | Score: %s | Balance post-trade: %.2f",
+                    signal.get("symbol", "n/a"),
+                    side,
+                    trade_amount,
+                    fill_price,
+                    signal.get("score", "n/a"),
+                    self.pnl,
                 )
             except Exception as exc:
-                self.logger.error(f"ERROR al ejecutar orden: {exc}")
+                self.logger.error("ERROR al ejecutar orden: %s", exc)
 
     def stats(self):
         """Return runtime trading statistics."""


### PR DESCRIPTION
## Summary
- add latest close price when generating signals
- warn if signal fields are missing
- update balance logic for buys and sells

## Testing
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6865a24f7a588331b1b3b28487a00279