### PR TITLE
Improve USDT balance handling and API key checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ API_KEY=your_key
 API_SECRET=your_secret
 ```
 These variables override the `api_key` and `api_secret` placeholders found in `config.yaml`. The key `cycle_sleep` controls the pause in seconds between trading cycles.
-The parameter `trade_size` defines the amount used for each trade.
+The parameter `trade_size` defines the USDT amount used for each trade. Set the
+initial available capital with `balance`.
 
 If a `.env` file exists, the `DataFeed` and `Trader` classes automatically load it at startup using `python-dotenv`.
 

--- a/config.yaml
+++ b/config.yaml
@@ -16,3 +16,4 @@ population_size: 4
 mutation_rate: 0.1
 selection_pct: 0.5
 trade_size: 10
+balance: 1000

--- a/models/manager.py
+++ b/models/manager.py
@@ -58,20 +58,24 @@ class ModelManager:
         for df in dfs:
             if not df.empty:
                 price = float(df["close"].astype(float).iloc[-1])
+                usdt_amount = self.config.get("trade_size", 10)
+                qty = usdt_amount / price if price else 0
                 signal = {
                     "symbol": df["symbol"].iloc[-1],
                     "side": "BUY",
                     "score": 1.0,
-                    "amount": self.config.get("trade_size", 10),
+                    "usdt_amount": usdt_amount,
                     "price": price,
+                    "qty": qty,
                 }
                 signals.append(signal)
                 self.logger.info(
-                    "Se\u00f1al detectada | Symbol: %s | Acci\u00f3n: %s | Score: %s | Monto: %s | Precio: %.2f",
+                    "Se\u00f1al detectada | Symbol: %s | Acci\u00f3n: %s | Score: %s | Monto USDT: %s | Qty: %.8f | Precio: %.2f",
                     signal.get("symbol", "n/a"),
                     signal.get("side", "n/a"),
                     signal.get("score", "n/a"),
-                    signal.get("amount", "n/a"),
+                    signal.get("usdt_amount", "n/a"),
+                    signal.get("qty", 0.0),
                     signal.get("price", float("nan")),
                 )
         return signals

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,19 @@
+import pytest
+from main import check_api_keys
+
+
+def test_live_mode_without_keys_raises(memory_logger, monkeypatch):
+    logger, _ = memory_logger
+    monkeypatch.delenv("API_KEY", raising=False)
+    monkeypatch.delenv("API_SECRET", raising=False)
+    config = {"mode": "live", "api_key": "", "api_secret": ""}
+    with pytest.raises(SystemExit):
+        check_api_keys(config, logger)
+
+
+def test_live_mode_with_keys_ok(memory_logger, monkeypatch):
+    logger, _ = memory_logger
+    monkeypatch.setenv("API_KEY", "k")
+    monkeypatch.setenv("API_SECRET", "s")
+    config = {"mode": "live"}
+    check_api_keys(config, logger)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -3,8 +3,8 @@ from trading.simulation import Simulator
 
 def test_simulator_logs_and_updates_balance(memory_logger):
     logger, stream = memory_logger
-    sim = Simulator({"trade_size": 1}, logger)
+    sim = Simulator({"trade_size": 10, "balance": 1000}, logger)
     start = sim.balance
     sim.simulate([{"price": 100, "symbol": "T", "side": "BUY"}])
-    assert sim.balance < start
+    assert sim.balance == start - 10
     assert "Modo: Simulado" in stream.getvalue()

--- a/trading/live.py
+++ b/trading/live.py
@@ -26,7 +26,7 @@ class Trader:
         self.api_key = os.environ.get("API_KEY", config.get("api_key"))
         self.api_secret = os.environ.get("API_SECRET", config.get("api_secret"))
         self.trades = 0
-        self.pnl = 0.0
+        self.balance = config.get("balance", 1000)
 
     def execute(self, signals):
         """Send trading orders for the provided signals."""
@@ -34,34 +34,42 @@ class Trader:
         for signal in signals:
             self.logger.info("Enviando orden real: %s", signal)
             try:
-                trade_amount = signal.get("amount")
-                if trade_amount is None:
-                    self.logger.warning("Falta campo 'amount' en signal: %s", signal)
-                    trade_amount = self.config.get("trade_size", 10)
-                if "price" not in signal:
+                usdt_amount = signal.get("usdt_amount")
+                if usdt_amount is None:
+                    self.logger.warning("Falta campo 'usdt_amount' en signal: %s", signal)
+                    usdt_amount = self.config.get("trade_size", 10)
+                price = signal.get("price")
+                if price is None:
                     self.logger.warning("Falta campo 'price' en signal: %s", signal)
-                fill_price = float(signal.get("price", 0))
+                    price = 0
+                qty = signal.get("qty", usdt_amount / price if price else 0)
+                fill_price = float(price)
                 side = signal.get("side")
                 # Aquí implementas llamada a la API de Binance para crear orden
                 self.trades += 1
                 if side == "BUY":
-                    self.pnl -= trade_amount * fill_price
+                    if usdt_amount > self.balance:
+                        self.logger.warning(
+                            f"Trade rechazado: monto ({usdt_amount}) mayor que el balance disponible ({self.balance})."
+                        )
+                        continue
+                    self.balance -= usdt_amount
                 elif side == "SELL":
-                    self.pnl += trade_amount * fill_price
+                    self.balance += qty * fill_price
                 else:
                     self.logger.warning("Valor 'side' inválido en signal: %s", signal)
                 self.logger.info(
-                    "Trade ejecutado | Modo: Real | Símbolo: %s | Acción: %s | Monto: %s | Precio: %.2f | Score: %s | Balance post-trade: %.2f",
+                    "Trade ejecutado | Modo: Real | Símbolo: %s | Acción: %s | Monto USDT: %s | Qty: %.8f | Precio: %.2f | Balance post-trade: %.2f",
                     signal.get("symbol", "n/a"),
                     side,
-                    trade_amount,
+                    usdt_amount,
+                    qty,
                     fill_price,
-                    signal.get("score", "n/a"),
-                    self.pnl,
+                    self.balance,
                 )
             except Exception as exc:
                 self.logger.error("ERROR al ejecutar orden: %s", exc)
 
     def stats(self):
         """Return runtime trading statistics."""
-        return {"trades": self.trades, "pnl": self.pnl}
+        return {"trades": self.trades, "balance": self.balance}


### PR DESCRIPTION
## Summary
- enforce trade amounts in USDT and compute qty
- simulate and live trading deduct from USDT balance
- require API keys at startup when running in live mode
- expose initial balance in config
- document configuration updates
- add tests for new behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings`

------
https://chatgpt.com/codex/tasks/task_e_6865a4e42a688331ab6ed5ced21068e5